### PR TITLE
Script tags have their javascript escaped for html

### DIFF
--- a/src/Lucid/Html5.hs
+++ b/src/Lucid/Html5.hs
@@ -342,8 +342,9 @@ samp_  :: Monad m => HtmlT m () -> HtmlT m ()
 samp_ = makeElement (Blaze.fromString "samp")
 
 -- | @script@ element
+-- | Will still html escape the javascript passed to it.
 script_  :: Monad m => HtmlT m () -> HtmlT m ()
-script_ = makeElement (Blaze.fromString "script")
+script_ = makeElement (Blaze.fromString "script") 
 
 -- | @section@ element
 section_  :: Monad m => HtmlT m () -> HtmlT m ()


### PR DESCRIPTION
This is a dummy PR meant to be deleted since issues seem to be disabled and the cabal file didn't mention an issue tracker.

I don't know if you've tried using inline script tags much but the auto escaping of text gets in the way, e.g.:

``` haskell
Prelude Lucid> script_ "var x = 'hello';" :: Html ()
<script>var x = &#39;hello&#39;;</script>
```

I normally wouldn't mind except using the `src` attribute for everything except that I was playing around with [Polymerjs](https://www.polymer-project.org/) and it's no fun doing that when creating new polymer elements, e.g.:

``` haskell
  polymerElement_ "hello-world" $ do
    template_ $ do
      with input_ [placeholder_ "Please enter your name", value_ "{{name}}"]
      p_ "Welcome, {{name}}!"
    script_ "Polymer({name:''});"  --  <--- This bit being key. The quotes will be escaped.
  ...
  helloWorld_ = makeElement (Blaze.fromString "hello-world")
```

Is there a workaround for this problem?

PS. great library. It seems like creating smart constructors could be a simple way to restrict inputs to custom elements which would be a big win over using a template language like haml.
