### PR TITLE
Use bytestring builder

### DIFF
--- a/lucid.cabal
+++ b/lucid.cabal
@@ -22,7 +22,7 @@ library
                      Lucid.Html5
                      Lucid.Bootstrap
   build-depends:     base >= 4 && <5
-                   , bytestring
+                   , bytestring >= 0.10.4
                    , containers
                    , mtl
                    , text

--- a/lucid.cabal
+++ b/lucid.cabal
@@ -22,7 +22,6 @@ library
                      Lucid.Html5
                      Lucid.Bootstrap
   build-depends:     base >= 4 && <5
-                   , blaze-builder
                    , bytestring
                    , containers
                    , mtl
@@ -51,7 +50,6 @@ benchmark bench
   build-depends:    base,
                     deepseq,
                     criterion,
-                    blaze-builder,
                     text,
                     bytestring,
                     lucid

--- a/src/Lucid/Base.hs
+++ b/src/Lucid/Base.hs
@@ -28,7 +28,7 @@ module Lucid.Base
    -- * Types
   ,Html
   ,HtmlT
-  ,Attribute
+  ,Attribute(..)
    -- * Classes
   ,Term(..)
   ,TermRaw(..)


### PR DESCRIPTION
I had a go at using bytestring builder instead of blaze and got a modest speed boost. Here's the bench marks on my laptop:

[bytestring-builder](http://lpaste.net/119270)
[blaze-builder](http://lpaste.net/119272)

I'm not 100% on the html escape but it passes all the tests. The biggest disadvantage is that it requires bytestring >= 10.4.

I also exposed the `Attribute` constructor (see diagrams/diagrams-svg#69) but I can revert it if you don't want to.