### PR TITLE
Needs GHC >= 7.4 due to usage of Data.Monoid.<>

### DIFF
--- a/lucid.cabal
+++ b/lucid.cabal
@@ -21,7 +21,7 @@ library
                      Lucid.Base
                      Lucid.Html5
                      Lucid.Bootstrap
-  build-depends:     base >= 4 && <5
+  build-depends:     base >= 4.5 && <5
                    , blaze-builder
                    , bytestring
                    , containers


### PR DESCRIPTION
http://matrix.hackage.haskell.org/package/lucid#GHC-7.2/lucid-2.9.2

I've revised existing versions (may take a moment for it to show up): http://hackage.haskell.org/package/lucid/revisions
