### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/lucid.cabal
+++ b/lucid.cabal
@@ -51,6 +51,7 @@ benchmark bench
   type:             exitcode-stdio-1.0
   hs-source-dirs:   benchmarks
   main-is:          Main.hs
+  other-modules:    HtmlBenchmarks
   build-depends:    base,
                     deepseq,
                     criterion,


### PR DESCRIPTION
Currently, the benchmarks fail to build when obtained from Hackage since the tarball does not ship with the `HtmlBenchmarks` module. This PR adds it explicitly.

See also https://github.com/fpco/stackage/issues/1372#issuecomment-213020065