### PR TITLE
Document methods of ToHtml

### DIFF
--- a/src/Lucid/Base.hs
+++ b/src/Lucid/Base.hs
@@ -186,7 +186,9 @@ instance (m ~ Identity) => Show (HtmlT m a) where
 
 -- | Can be converted to HTML.
 class ToHtml a where
+  -- | Convert to HTML, doing HTML escaping.
   toHtml :: Monad m => a -> HtmlT m ()
+  -- | Convert to HTML without any escaping.
   toHtmlRaw :: Monad m => a -> HtmlT m ()
 
 instance (a ~ (), m ~ Identity) => ToHtml (HtmlT m a) where


### PR DESCRIPTION
Inferred from looking at [blaze-builder source code](https://hackage.haskell.org/package/blaze-builder-0.1/docs/src/Text-Blaze-Builder-Html.html#fromHtmlEscapedString).