### PR TITLE
Relaxed contexts for HtmlT's Semigroup, Monoid, Functor, Applicative instances

### DIFF
--- a/benchmarks/IO.hs
+++ b/benchmarks/IO.hs
@@ -3,12 +3,13 @@ module Main where
 
 import Lucid
 import Criterion.Main
+import Control.Applicative (Applicative)
 import Control.Monad (replicateM_)
 import qualified Data.Text.Lazy as LT
 import Control.Monad.Trans.Reader (runReader)
 import Data.Functor.Identity (runIdentity)
 
-lotsOfDivs :: Monad m => Int -> HtmlT m ()
+lotsOfDivs :: (Applicative m, Monad m) => Int -> HtmlT m ()
 lotsOfDivs n = body_
   $ replicateM_ n
   $ div_ "hello world!"

--- a/src/Lucid/Base.hs
+++ b/src/Lucid/Base.hs
@@ -106,11 +106,11 @@ instance MFunctor HtmlT where
   hoist f (HtmlT xs) = HtmlT (f xs)
 
 -- | @since 2.9.7
-instance (Semigroup a,Applicative m) => Semigroup (HtmlT m a) where
+instance (a ~ (),Applicative m) => Semigroup (HtmlT m a) where
   (<>) = liftA2 (<>)
 
 -- | Monoid is right-associative, a la the 'Builder' in it.
-instance (Monoid a,Applicative m) => Monoid (HtmlT m a) where
+instance (a ~ (),Applicative m) => Monoid (HtmlT m a) where
   mempty  = pure mempty
   mappend = liftA2 mappend
 

--- a/src/Lucid/Base.hs
+++ b/src/Lucid/Base.hs
@@ -120,15 +120,15 @@ instance Applicative m => Applicative (HtmlT m) where
   {-# INLINE pure #-}
 
   f <*> x = HtmlT $ mk <$> runHtmlT f <*> runHtmlT x
-    where mk (g, f') (h, x') = (g <> h, f' x')
+    where mk ~(g, f') ~(h, x') = (g <> h, f' x')
   {-# INLINE (<*>) #-}
 
   m *> n = HtmlT $ mk <$> runHtmlT m <*> runHtmlT n
-    where mk (g, _) (h, b) = (g <> h, b)
+    where mk ~(g, _) ~(h, b) = (g <> h, b)
   {-# INLINE (*>) #-}
 
   m <* n = HtmlT $ mk <$> runHtmlT m <*> runHtmlT n
-    where mk (g, a) (h, _) = (g <> h, a)
+    where mk ~(g, a) ~(h, _) = (g <> h, a)
   {-# INLINE (<*) #-}
 
 -- | Just re-uses Monad.

--- a/src/Lucid/Html5.hs
+++ b/src/Lucid/Html5.hs
@@ -8,6 +8,7 @@ module Lucid.Html5 where
 
 import           Lucid.Base
 
+import           Control.Applicative
 import           Data.Monoid
 import           Data.Text (Text, unwords)
 

--- a/src/Lucid/Html5.hs
+++ b/src/Lucid/Html5.hs
@@ -15,14 +15,12 @@ import           Data.Text (Text, unwords)
 -- Elements
 
 -- | @DOCTYPE@ element
-doctype_ :: Monad m => HtmlT m ()
+doctype_ :: Applicative m => HtmlT m ()
 doctype_ = makeElementNoEnd "!DOCTYPE HTML"
 
 -- | @DOCTYPE@ element + @html@ element
-doctypehtml_ :: Monad m => HtmlT m a -> HtmlT m a
-doctypehtml_ m =
-  do doctype_
-     html_ m
+doctypehtml_ :: Applicative m => HtmlT m a -> HtmlT m a
+doctypehtml_ m = doctype_ *> html_ m
 
 -- | @a@ element
 a_ :: Term arg result => arg -> result
@@ -37,7 +35,7 @@ address_ :: Term arg result => arg -> result
 address_ = term "address"
 
 -- | @area@ element
-area_ :: Monad m => [Attribute] -> HtmlT m ()
+area_ :: Applicative m => [Attribute] -> HtmlT m ()
 area_ = with (makeElementNoEnd "area")
 
 -- | @article@ element
@@ -57,7 +55,7 @@ b_ :: Term arg result => arg -> result
 b_ = term "b"
 
 -- | @base@ element
-base_ :: Monad m => [Attribute] -> HtmlT m ()
+base_ :: Applicative m => [Attribute] -> HtmlT m ()
 base_ = with (makeElementNoEnd "base")
 
 -- | @bdo@ element
@@ -73,7 +71,7 @@ body_ :: Term arg result => arg -> result
 body_ = term "body"
 
 -- | @br@ element
-br_ :: Monad m => [Attribute] -> HtmlT m ()
+br_ :: Applicative m => [Attribute] -> HtmlT m ()
 br_ = with (makeElementNoEnd "br")
 
 -- | @button@ element
@@ -97,7 +95,7 @@ code_ :: Term arg result => arg -> result
 code_ = term "code"
 
 -- | @col@ element
-col_ :: Monad m => [Attribute] -> HtmlT m ()
+col_ :: Applicative m => [Attribute] -> HtmlT m ()
 col_ = with (makeElementNoEnd "col")
 
 -- | @colgroup@ element
@@ -145,7 +143,7 @@ em_ :: Term arg result => arg -> result
 em_ = term "em"
 
 -- | @embed@ element
-embed_ :: Monad m => [Attribute] -> HtmlT m ()
+embed_ :: Applicative m => [Attribute] -> HtmlT m ()
 embed_ = with (makeElementNoEnd "embed")
 
 -- | @fieldset@ element
@@ -205,7 +203,7 @@ hgroup_ :: Term arg result => arg -> result
 hgroup_ = term "hgroup"
 
 -- | @hr@ element
-hr_ :: Monad m => [Attribute] -> HtmlT m ()
+hr_ :: Applicative m => [Attribute] -> HtmlT m ()
 hr_ = with (makeElementNoEnd "hr")
 
 -- | @html@ element
@@ -221,11 +219,11 @@ iframe_ :: Term arg result => arg -> result
 iframe_ = term "iframe"
 
 -- | @img@ element
-img_ :: Monad m => [Attribute] -> HtmlT m ()
+img_ :: Applicative m => [Attribute] -> HtmlT m ()
 img_ = with (makeElementNoEnd "img")
 
 -- | @input@ element
-input_ :: Monad m => [Attribute] -> HtmlT m ()
+input_ :: Applicative m => [Attribute] -> HtmlT m ()
 input_ = with (makeElementNoEnd "input")
 
 -- | @ins@ element
@@ -237,7 +235,7 @@ kbd_ :: Term arg result => arg -> result
 kbd_ = term "kbd"
 
 -- | @keygen@ element
-keygen_ :: Monad m => [Attribute] -> HtmlT m ()
+keygen_ :: Applicative m => [Attribute] -> HtmlT m ()
 keygen_ = with (makeElementNoEnd "keygen")
 
 -- | @label@ element or @label@ attribute
@@ -253,7 +251,7 @@ li_ :: Term arg result => arg -> result
 li_ = term "li"
 
 -- | @link@ element
-link_ :: Monad m => [Attribute] -> HtmlT m ()
+link_ :: Applicative m => [Attribute] -> HtmlT m ()
 link_ = with (makeElementNoEnd "link")
 
 -- | @map@ element
@@ -273,11 +271,11 @@ menu_ :: Term arg result => arg -> result
 menu_ = term "menu"
 
 -- | @menuitem@ element
-menuitem_ :: Monad m => [Attribute] -> HtmlT m ()
+menuitem_ :: Applicative m => [Attribute] -> HtmlT m ()
 menuitem_ = with (makeElementNoEnd "menuitem")
 
 -- | @meta@ element
-meta_ :: Monad m => [Attribute] -> HtmlT m ()
+meta_ :: Applicative m => [Attribute] -> HtmlT m ()
 meta_ = with (makeElementNoEnd "meta")
 
 -- | @meter@ element
@@ -317,7 +315,7 @@ p_ :: Term arg result => arg -> result
 p_ = term "p"
 
 -- | @param@ element
-param_ :: Monad m => [Attribute] -> HtmlT m ()
+param_ :: Applicative m => [Attribute] -> HtmlT m ()
 param_ = with (makeElementNoEnd "param")
 
 -- | The @svg@ attribute.
@@ -369,7 +367,7 @@ small_ :: Term arg result => arg -> result
 small_ = term "small"
 
 -- | @source@ element
-source_ :: Monad m => [Attribute] -> HtmlT m ()
+source_ :: Applicative m => [Attribute] -> HtmlT m ()
 source_ = with (makeElementNoEnd "source")
 
 -- | @span@ element or @span@ attribute
@@ -441,7 +439,7 @@ tr_ :: Term arg result => arg -> result
 tr_ = term "tr"
 
 -- | @track@ element
-track_ :: Monad m => [Attribute] -> HtmlT m ()
+track_ :: Applicative m => [Attribute] -> HtmlT m ()
 track_ = with (makeElementNoEnd "track")
 
 -- | @ul@ element
@@ -457,7 +455,7 @@ video_ :: Term arg result => arg -> result
 video_ = term "video"
 
 -- | @wbr@ element
-wbr_ :: Monad m => [Attribute] -> HtmlT m ()
+wbr_ :: Applicative m => [Attribute] -> HtmlT m ()
 wbr_ = with (makeElementNoEnd "wbr")
 
 -------------------------------------------------------------------------------

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,6 +10,7 @@ import Lucid
 import Lucid.Base
 import Lucid.Bootstrap
 
+import Control.Applicative
 import Control.Monad.State.Strict
 
 import Example1
@@ -206,7 +207,7 @@ testCommuteHtmlT =
   where
     example = renderText $ evalState (commuteHtmlT exampleHtml) 1
 
-    exampleHtml :: MonadState Int m => HtmlT m ()
+    exampleHtml :: (Applicative m, MonadState Int m) => HtmlT m ()
     exampleHtml = ul_ $ replicateM_ 5 $ do
       x <- get
       put (x + 1)


### PR DESCRIPTION
The existing contexts were more restrictive than they needed to be.