### PR TITLE
Post-AMP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,6 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-7.4.2"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.4.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-7.6.3"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.3], sources: [hvr-ghc]}}
-    - compiler: "ghc-7.8.4"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.8.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.10.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.10.3], sources: [hvr-ghc]}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.9.10
+
+* Drop GHC-7.8 and older (pre-AMP) support
+* Generalise type-signatures to require only `Applicative` or `Functor`,
+  when that's enough
+
 ## 2.9.9
 
 * Add `commuteHtmlT` to commute `HtmlT m a` into `m (HtmlT n a)`.

--- a/lucid.cabal
+++ b/lucid.cabal
@@ -1,8 +1,16 @@
 name:                lucid
-version:             2.9.9
+version:             2.9.10
 synopsis:            Clear to write, read and edit DSL for HTML
-description:         Clear to write, read and edit DSL for HTML. See the 'Lucid' module
-                     for description and documentation.
+description:
+  Clear to write, read and edit DSL for HTML.
+  .
+  * Names are consistent, and do not conflict with base or are keywords (all have suffix @_@)
+  .
+  * Same combinator can be used for attributes and elements (e.g. 'style_')
+  .
+  * For more, read <https://chrisdone.com/posts/lucid the blog post>
+  .
+  See the "Lucid" module for more documentation.
 homepage:            https://github.com/chrisdone/lucid
 license:             BSD3
 license-file:        LICENSE
@@ -13,7 +21,7 @@ category:            Web
 build-type:          Simple
 cabal-version:       >=1.8
 extra-source-files:  README.md, CHANGELOG.md
-tested-with:         GHC==7.4.2,GHC==7.6.3,GHC==7.8.4,GHC==7.10.3,GHC==8.0.2,GHC==8.2.2,GHC==8.4.1
+tested-with:         GHC==7.10.3,GHC==8.0.2,GHC==8.2.2,GHC==8.4.1
 
 library
   hs-source-dirs:    src/
@@ -22,7 +30,7 @@ library
                      Lucid.Base
                      Lucid.Html5
                      Lucid.Bootstrap
-  build-depends:     base >= 4.5 && <5
+  build-depends:     base >= 4.8 && <5
                    , blaze-builder
                    , bytestring
                    , containers

--- a/src/Lucid/Base.hs
+++ b/src/Lucid/Base.hs
@@ -183,9 +183,9 @@ instance MonadError e m => MonadError e (HtmlT m) where
 -- | @since 2.9.9
 instance MonadWriter w m => MonadWriter w (HtmlT m) where
     tell             = lift . tell
-    listen (HtmlT x) = HtmlT $ liftM reassoc $ listen x
+    listen (HtmlT x) = HtmlT $ fmap reassoc $ listen x
       where reassoc ((a, b), c) = (a, (b, c))
-    pass (HtmlT p)   = HtmlT $ pass $ liftM assoc p
+    pass (HtmlT p)   = HtmlT $ pass $ fmap assoc p
       where assoc (a, (b, c)) = ((a, b), c)
 
 -- | If you want to use IO in your HTML generation.
@@ -313,12 +313,12 @@ class TermRaw arg result | result -> arg where
            -> result        -- ^ Result: either an element or an attribute.
 
 -- | Given attributes, expect more child input.
-instance (Functor m, Monad m,ToHtml f, a ~ ()) => TermRaw [Attribute] (f -> HtmlT m a) where
+instance (Monad m,ToHtml f, a ~ ()) => TermRaw [Attribute] (f -> HtmlT m a) where
   termRawWith name f attrs = with (makeElement name) (attrs <> f) . toHtmlRaw
 
 -- | Given children immediately, just use that and expect no
 -- attributes.
-instance (Functor m, Monad m,a ~ ()) => TermRaw Text (HtmlT m a) where
+instance (Monad m,a ~ ()) => TermRaw Text (HtmlT m a) where
   termRawWith name f = with (makeElement name) f . toHtmlRaw
 
 -- | Some termRaws (like 'Lucid.Html5.style_', 'Lucid.Html5.title_') can be used for
@@ -393,7 +393,7 @@ renderText = LT.decodeUtf8 . Blaze.toLazyByteString . runIdentity . execHtmlT
 -- the lower-level behaviour.
 --
 renderBST :: Monad m => HtmlT m a -> m ByteString
-renderBST = liftM Blaze.toLazyByteString . execHtmlT
+renderBST = fmap Blaze.toLazyByteString . execHtmlT
 
 -- | Render the HTML to a lazy 'Text', but in a monad.
 --
@@ -402,7 +402,7 @@ renderBST = liftM Blaze.toLazyByteString . execHtmlT
 -- you're interested in the lower-level behaviour.
 --
 renderTextT :: Monad m => HtmlT m a -> m LT.Text
-renderTextT = liftM (LT.decodeUtf8 . Blaze.toLazyByteString) . execHtmlT
+renderTextT = fmap (LT.decodeUtf8 . Blaze.toLazyByteString) . execHtmlT
 
 --------------------------------------------------------------------------------
 -- Running, transformer versions

--- a/src/Lucid/Html5.hs
+++ b/src/Lucid/Html5.hs
@@ -8,7 +8,6 @@ module Lucid.Html5 where
 
 import           Lucid.Base
 
-import           Control.Applicative
 import           Data.Monoid
 import           Data.Text (Text, unwords)
 


### PR DESCRIPTION
I *think* that relaxing `Monad m` to `Applicative m` or `Functor m` shouldn't break anything, so we can release this with a minor bump only.

I'll try to compile our codebase + few revdeps to get some empirical evidence though.

(EDITED: should to shouldn't)