### PR TITLE
Add lower bounds

### DIFF
--- a/lucid.cabal
+++ b/lucid.cabal
@@ -1,5 +1,6 @@
 name:                lucid
 version:             2.9.10
+x-revision:          1
 synopsis:            Clear to write, read and edit DSL for HTML
 description:
   Clear to write, read and edit DSL for HTML.
@@ -30,18 +31,26 @@ library
                      Lucid.Base
                      Lucid.Html5
                      Lucid.Bootstrap
-  build-depends:     base >= 4.8 && <5
-                   , blaze-builder
-                   , bytestring
-                   , containers
-                   , hashable
-                   , mmorph
-                   , mtl
-                   , text
-                   , transformers
-                   , unordered-containers
+
+  -- GHC boot libraries
+  build-depends:     base                   >=4.8      && <4.12
+                   , bytestring             >=0.10.6.0
+                   , containers             >=0.5.6.2
+                   , transformers           >=0.4.2.0
+
+  -- GHC boot libraries since 8.4.
+  build-depends:     mtl                    >=2.2
+                   , text                   >=1.2.0.2
+
+  -- compat packages
   if !impl(ghc >= 8.0)
-    build-depends:   semigroups
+    build-depends:   semigroups            >=0.16.1
+
+  -- other dependencies
+  build-depends:     blaze-builder         >=0.4.0.0
+                   , hashable              >=1.2.3.2
+                   , mmorph                >=1.0.3
+                   , unordered-containers  >=0.2.5.1
 
 test-suite test
     type: exitcode-stdio-1.0


### PR DESCRIPTION
semigroups and blaze-builder are strict (older releases causecompilation failures), GHC  boot libraries allow versions bundled with GHC-7.10.3, others are oldest version there were an install plan.