### PR TITLE
Retain ordering of attributes as they're defined by switching from `Map Text Text` to `Seq (Text, Text)`

### DIFF
--- a/src/Lucid/Base.hs
+++ b/src/Lucid/Base.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE TupleSections #-}
 
 -- Search for UndecidableInstances to see why this is needed
 {-# LANGUAGE UndecidableInstances #-}

--- a/src/Lucid/Base.hs
+++ b/src/Lucid/Base.hs
@@ -53,12 +53,12 @@ import           Control.Monad.Writer.Class (MonadWriter(..))
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString as S
+import qualified Data.Foldable as Foldable
 import           Data.Functor.Identity
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
+import Data.Sequence (Seq(..))
+import qualified Data.Sequence as Seq
 import           Data.Hashable (Hashable(..))
-import           Data.Semigroup (Semigroup (..))
-import           Data.Monoid (Monoid (..))
 import           Data.String
 import           Data.Text (Text)
 import qualified Data.Text.Lazy as LT

--- a/src/Lucid/Base.hs
+++ b/src/Lucid/Base.hs
@@ -87,7 +87,7 @@ type Html = HtmlT Identity
 -- | A monad transformer that generates HTML. Use the simpler 'Html'
 -- type if you don't want to transform over some other monad.
 newtype HtmlT m a =
-  HtmlT {runHtmlT :: m (Map Text Text -> Builder,a)
+  HtmlT {runHtmlT :: m (Seq (Text, Text) -> Builder,a)
          -- ^ This is the low-level way to run the HTML transformer,
          -- finally returning an element builder and a value. You can
          -- pass 'mempty' for this argument for a top-level call. See


### PR DESCRIPTION
By using `Seq (Text, Text)` instead of `Map Text Text`, we can ensure attributes retain their original order as defined in the Lucid EDSL and not be reordered by attribute name. Fixes #115.