### PR TITLE
Add `minlength` attribute

### DIFF
--- a/lucid1/src/Lucid/Html5.hs
+++ b/lucid1/src/Lucid/Html5.hs
@@ -711,6 +711,10 @@ method_ = makeAttribute "method"
 min_ :: Text -> Attribute
 min_ = makeAttribute "min"
 
+-- | The @minlength@ attribute.
+minlength_ :: Text -> Attribute
+minlength_ = makeAttribute "minlength"
+
 -- | The @multiple@ attribute.
 multiple_ :: Text -> Attribute
 multiple_ = makeAttribute "multiple"


### PR DESCRIPTION
Noticed the [`minlength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-minlength) attribute for client-side valiation was missing.