### PR TITLE
Bump to 0.0.20220526

### DIFF
--- a/lucid2/CHANGELOG.md
+++ b/lucid2/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.20220526
+
+This release adds some extra functions for running different monad
+stacks, prompted by Joe Vargas.
+
+* Add `generalizeHtmlT`, `commuteHtmlT` and `hoistHtmlT`.
+* Deprecate the accidentally exported `relaxHtmlT = undefined`.
+
 ## 0.0.20220509
 
 * Use explicit imports for mtl, avoiding mtl-2.3 incompatibility.

--- a/lucid2/lucid2.cabal
+++ b/lucid2/lucid2.cabal
@@ -1,5 +1,5 @@
 name:                lucid2
-version:             0.0.20220509
+version:             0.0.20220526
 synopsis:            Clear to write, read and edit DSL for HTML
 description:
   Clear to write, read and edit DSL for HTML.


### PR DESCRIPTION
This release adds some extra functions for running different monad
stacks, prompted by Joe Vargas.

* Add `generalizeHtmlT`, `commuteHtmlT` and `hoistHtmlT`.
* Deprecate the accidentally exported `relaxHtmlT = undefined`.

Closes #133.