### PR TITLE
fix behaviour of commuteHtmlT in lucid2 (fixes #135)

### DIFF
--- a/lucid2/src/Lucid/Base.hs
+++ b/lucid2/src/Lucid/Base.hs
@@ -342,7 +342,7 @@ commuteHtmlT :: (Monad m, Monad n)
              -> m (HtmlT n a)  -- ^ Commuted monads. /Note:/ @n@ can be 'Identity'
 commuteHtmlT h = do
   (builder, a) <- runHtmlT h
-  return . HtmlT $ put builder >> return a
+  return . HtmlT $ modify' (<> builder) >> return a
 
 -- | Evaluate the HTML to its return value. Analogous to @evalState@.
 --

--- a/lucid2/test/Main.hs
+++ b/lucid2/test/Main.hs
@@ -30,6 +30,7 @@ spec = do
   describe "attributes" testAttributes
   describe "special-elements" testSpecials
   describe "self-closing" testSelfClosing
+  describe "commute" testCommute
 
 (==?*) :: (Eq a, Show a) => a -> [a] -> Assertion
 x ==?* xs | x `elem` xs = return ()
@@ -154,3 +155,12 @@ testSelfClosing =
      it "input"
         (renderText (input_ [type_ "text"]) `shouldBe`
          "<input type=\"text\">")
+
+testCommute :: Spec
+testCommute = do
+  it "commutes" $ do
+    let stateAction :: HtmlT (Control.Monad.State.Strict.State [Integer]) ()
+        stateAction = div_ [class_ "inside"] $ pure ()
+        (fragment, _s) = runState (commuteHtmlT stateAction) [0]
+    renderText (div_ [class_ "outside"] fragment) `shouldBe`
+     "<div class=\"outside\"><div class=\"inside\"></div></div>"


### PR DESCRIPTION
this should fix issue #135 by not clobbering `HtmlT`'s internal state when running a commuted `Html a`

it's a breaking change I guess? I hope that noone's relying on malformed HTML generation, but :shrug:  

(also, apologies for the formatting, I couldn't figure out the style exactly)