### PR TITLE
Import `Control.Monad` in `test/Main.hs`

### DIFF
--- a/lucid1/lucid.cabal
+++ b/lucid1/lucid.cabal
@@ -33,7 +33,7 @@ library
                      Lucid.Bootstrap
 
   -- GHC boot libraries
-  build-depends:     base                   >=4.8      && <4.18
+  build-depends:     base                   >=4.8      && <4.19
                    , bytestring             >=0.10.6.0
                    , containers             >=0.5.6.2
                    , transformers           >=0.4.2.0

--- a/lucid1/test/Main.hs
+++ b/lucid1/test/Main.hs
@@ -11,6 +11,7 @@ import Lucid
 import Lucid.Base
 import Lucid.Bootstrap
 
+import Control.Monad
 import Control.Applicative
 import Control.Monad.State.Strict
 


### PR DESCRIPTION
mtl-2.3 stops reexporting `Control.Monad`